### PR TITLE
Allow configurable Playwright version

### DIFF
--- a/commands/web/install-playwright
+++ b/commands/web/install-playwright
@@ -8,6 +8,9 @@ set -e
 
 echo "Installing Playwright browsers and dependencies..."
 
+# Use PLAYWRIGHT_VERSION environment variable, default to "latest"
+VERSION="${PLAYWRIGHT_VERSION:-latest}"
+
 # Check if browsers are already installed
 if [ -f /opt/playwright-browsers/.installed ]; then
     echo "✓ Playwright browsers are already installed at /opt/playwright-browsers"
@@ -47,16 +50,17 @@ else
             source ~/.nvm/nvm.sh
             nvm use 22 2>/dev/null || true
         fi
-        echo 'n' | npm init playwright@latest -- --quiet --lang=TypeScript --no-browsers || {
+
+        echo 'n' | npm init playwright@${VERSION} -- --quiet --lang=TypeScript --no-browsers || {
           echo 'Playwright init failed, trying alternative approach...'
           npm init -y
-          npm install @playwright/test@latest
+          npm install @playwright/test@${VERSION}
           npx playwright init --yes --lang=TypeScript --no-browsers
         }
     else
         # Install Playwright dependencies
         echo "Installing Playwright dependencies..."
-        npm install @playwright/test@latest
+        npm install @playwright/test@${VERSION}
     fi
 
     # Install browsers to the persistent location
@@ -91,7 +95,7 @@ if [ -f package.json ]; then
         npx playwright install --list
     else
         echo "⚠️  Playwright not installed in project. Installing dependencies..."
-        npm install @playwright/test@latest
+        npm install @playwright/test@${VERSION}
         npx playwright --version
         echo ""
         echo "Installed browsers:"

--- a/config.playwright.yaml
+++ b/config.playwright.yaml
@@ -18,6 +18,7 @@ web_environment:
   - PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
   - PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1  # Skip download since browsers are pre-installed
   - PLAYWRIGHT_TEST_DIR=${PLAYWRIGHT_TEST_DIR:-tests}  # Default test directory (can be overridden in config.yaml)
+  - PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION:-latest} # Default playwright version (can be overridden in config.yaml)
 
 # Create a volume to persist npm cache (optional, helps with npm install speed)
 additional_hostnames: []

--- a/install.yaml
+++ b/install.yaml
@@ -60,6 +60,9 @@ post_install_actions:
     # Use PLAYWRIGHT_TEST_DIR environment variable, default to "tests"
     TEST_DIR="${PLAYWRIGHT_TEST_DIR:-tests}"
     
+    # Use PLAYWRIGHT_VERSION environment variable, default to "latest"
+    VERSION="${PLAYWRIGHT_VERSION:-latest}"
+    
     # Create ${TEST_DIR}/playwright directory if it doesn't exist
     if [ ! -d "${DDEV_APPROOT}/${TEST_DIR}/playwright" ]; then
       mkdir -p "${DDEV_APPROOT}/${TEST_DIR}/playwright"
@@ -89,10 +92,10 @@ post_install_actions:
 
       # Initialize Playwright project non-interactively
       # This creates package.json, playwright.config.ts, and example tests
-      echo 'n' | npm init playwright@latest -- --quiet --lang=TypeScript --no-browsers || {
+      echo 'n' | npm init playwright@${VERSION} -- --quiet --lang=TypeScript --no-browsers || {
         echo 'Playwright init failed, trying alternative approach...'
         npm init -y
-        npm install @playwright/test@latest
+        npm install @playwright/test@${VERSION}
         npx playwright init --yes --lang=TypeScript --no-browsers
       }
 

--- a/install.yaml
+++ b/install.yaml
@@ -60,9 +60,6 @@ post_install_actions:
     # Use PLAYWRIGHT_TEST_DIR environment variable, default to "tests"
     TEST_DIR="${PLAYWRIGHT_TEST_DIR:-tests}"
     
-    # Use PLAYWRIGHT_VERSION environment variable, default to "latest"
-    VERSION="${PLAYWRIGHT_VERSION:-latest}"
-    
     # Create ${TEST_DIR}/playwright directory if it doesn't exist
     if [ ! -d "${DDEV_APPROOT}/${TEST_DIR}/playwright" ]; then
       mkdir -p "${DDEV_APPROOT}/${TEST_DIR}/playwright"
@@ -89,6 +86,9 @@ post_install_actions:
         nvm install 22 2>/dev/null || true
         nvm use 22 2>/dev/null || true
       fi
+    
+      # Use PLAYWRIGHT_VERSION environment variable, default to "latest"
+      VERSION="${PLAYWRIGHT_VERSION:-latest}"
 
       # Initialize Playwright project non-interactively
       # This creates package.json, playwright.config.ts, and example tests

--- a/install.yaml
+++ b/install.yaml
@@ -92,10 +92,10 @@ post_install_actions:
 
       # Initialize Playwright project non-interactively
       # This creates package.json, playwright.config.ts, and example tests
-      echo 'n' | npm init playwright@${VERSION} -- --quiet --lang=TypeScript --no-browsers || {
+      echo 'n' | npm init playwright@${PLAYWRIGHT_VERSION:-latest} -- --quiet --lang=TypeScript --no-browsers || {
         echo 'Playwright init failed, trying alternative approach...'
         npm init -y
-        npm install @playwright/test@${VERSION}
+        npm install @playwright/test@${PLAYWRIGHT_VERSION:-latest}
         npx playwright init --yes --lang=TypeScript --no-browsers
       }
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -46,7 +46,7 @@ teardown() {
 
 @test "install from directory" {
   set -eu -o pipefail
-  cd ${TESTDIR}
+  cd "${TESTDIR}"
 
   echo "# Basic site check" >&3
   health_checks

--- a/web-build/Dockerfile.playwright
+++ b/web-build/Dockerfile.playwright
@@ -76,7 +76,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     node --version && npm --version
     # Pre-install Playwright and download browsers
     # Using latest version for most up-to-date features
-RUN npm install -g playwright@${VERSION} && \
+RUN npm install -g playwright@${PLAYWRIGHT_VERSION} && \
     npx playwright install-deps && \
     npx playwright install && \
     # Clean up npm cache to reduce image size

--- a/web-build/Dockerfile.playwright
+++ b/web-build/Dockerfile.playwright
@@ -76,7 +76,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     node --version && npm --version
     # Pre-install Playwright and download browsers
     # Using latest version for most up-to-date features
-RUN npm install -g playwright@latest && \
+RUN npm install -g playwright@${VERSION} && \
     npx playwright install-deps && \
     npx playwright install && \
     # Clean up npm cache to reduce image size


### PR DESCRIPTION
Hey there, 
Big fan of your Add-on, really helps with getting Playwright to work within a bigger team of developers!
The goal of this PR is to set the version of playwright manually, so that there can be organized patches across a whole team of developers.
I used your latest patch regarding the test-location as an inspiration. I tried to implement it myself but I can not make it work, I think the Issue is in install.yaml where it can not decode PLAYWRIGHT_VERSION and silently falls back to "latest". 
 
 Other than that I think I got all the neccessary locations.
 
Greetings 
Fabian :)