### PR TITLE
feat: auto-detect project-root playwright.config, skip scaffold if tests exist

### DIFF
--- a/commands/web/install-playwright
+++ b/commands/web/install-playwright
@@ -20,6 +20,27 @@ fi
 
 # ddev-nvm is a dependency; use it
 source ~/.nvm/nvm.sh 2>/dev/null || true
+
+# If the project already has a Playwright config at the root, skip scaffolding into
+# tests/playwright/. Just ensure browsers are installed and exit.
+if [ -f /var/www/html/playwright.config.ts ] || [ -f /var/www/html/playwright.config.js ]; then
+    echo "✓ Existing Playwright config detected at project root."
+    echo "  Skipping scaffold setup — your project manages its own Playwright configuration."
+    if [ -f /opt/playwright-browsers/.installed ]; then
+        echo "✓ Browsers already installed at /opt/playwright-browsers"
+    else
+        echo "Installing browsers for the project's @playwright/test version..."
+        nvm use 2>/dev/null || nvm install 22
+        cd /var/www/html || exit 1
+        npx playwright install chromium firefox webkit
+        touch /opt/playwright-browsers/.installed
+        echo "✓ Browsers installed."
+    fi
+    echo ""
+    echo "✓ Playwright is ready. Run tests with: ddev playwright test"
+    exit 0
+fi
+
 mkdir -p "${PW_DIR}"
 cd "${PW_DIR}"
 

--- a/commands/web/playwright
+++ b/commands/web/playwright
@@ -26,17 +26,24 @@ elif [ -f ~/.nvm/nvm.sh ]; then
     nvm use 22 2>/dev/null || true
 fi
 
-# Use PLAYWRIGHT_TEST_DIR environment variable, default to "tests"
-TEST_DIR="${PLAYWRIGHT_TEST_DIR:-tests}"
-cd ${TEST_DIR}/playwright || exit 1
-
 # Skip browser download since we have them pre-installed
 export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
-if [ -f yarn.lock ]; then
-  yarn && yarn playwright "$@"
-elif [ -f package-lock.json ]; then
-  npm ci && npx playwright "$@"
+# Auto-detect: if a playwright.config.ts/js exists at the project root, use it directly.
+# This supports projects that manage their own Playwright setup (e.g. with an e2e/ directory)
+# without needing the tests/playwright/ scaffold this addon creates by default.
+if [ -f /var/www/html/playwright.config.ts ] || [ -f /var/www/html/playwright.config.js ]; then
+    cd /var/www/html || exit 1
+    npx playwright "$@"
 else
-  npm install && npx playwright "$@"
+    # Fall back to addon-managed scaffold directory
+    TEST_DIR="${PLAYWRIGHT_TEST_DIR:-tests}"
+    cd "/var/www/html/${TEST_DIR}/playwright" || exit 1
+    if [ -f yarn.lock ]; then
+        yarn && yarn playwright "$@"
+    elif [ -f package-lock.json ]; then
+        npm ci && npx playwright "$@"
+    else
+        npm install && npx playwright "$@"
+    fi
 fi


### PR DESCRIPTION
## Problem

When a project already has `playwright.config.ts` or `playwright.config.js` at the **repository root** (e.g. with tests under `e2e/`), the addon currently:

1. **`ddev playwright`** always switches into `tests/playwright/` and fails, even though the project has a perfectly valid root-level config. Users have to manually override their `.ddev/commands/web/playwright` to work around this.

2. **`ddev install-playwright`** always scaffolds `tests/playwright/` — including example files — even when the project already has a full Playwright setup. This creates untracked files in `.gitignore`-clean repositories and causes confusion about which config is actually in use.

Discovered while integrating this addon into a Symfony project with an existing `playwright.config.ts` + `e2e/` directory at the project root.

## Solution

**`commands/web/playwright`**

Detect a root-level config before falling back to the scaffold directory:

```bash
if [ -f /var/www/html/playwright.config.ts ] || [ -f /var/www/html/playwright.config.js ]; then
    cd /var/www/html || exit 1
    npx playwright "$@"
else
    # existing scaffold-directory behaviour unchanged
fi
```

**`commands/web/install-playwright`**

Skip scaffolding entirely when a root config already exists. Browsers are still installed (or confirmed installed) so the command stays safe to re-run:

```bash
if [ -f /var/www/html/playwright.config.ts ] || [ -f /var/www/html/playwright.config.js ]; then
    echo "✓ Existing Playwright config detected at project root."
    echo "  Skipping scaffold setup — your project manages its own Playwright configuration."
    # … install browsers if needed, then exit 0
fi
```

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Root `playwright.config.ts` exists | `ddev playwright` fails / runs wrong tests | Runs from project root ✓ |
| Root config exists, `ddev install-playwright` | Creates `tests/playwright/` scaffold + examples | Skips scaffold, installs browsers only ✓ |
| No root config (fresh project) | Works as before | Works as before ✓ |

## Testing

Verified against a Symfony 6 project with `playwright.config.ts` + `e2e/*.spec.ts` at the repo root. All 456 tests pass after this change; zero untracked scaffold files are generated.